### PR TITLE
Handle ptrace 'access mode check' failures more gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ If any requirements are missing when you run the script, the script lists the mi
     *   `--jvm-heap`: include the optional JVM heap dump diagnostic. Halts the JVM temporarily for the duration of the diagnostic. Only include this diagnostic when requested by Caplin Support.
     *   `--jvm-class-histogram`: include the optional JVM class histogram diagnostic. Halts the JVM temporarily for the duration of the diagnostic. Only include this diagnostic when requested by Caplin Support.
     *   `--strace`: include the optional `strace` diagnostic. Only include this diagnostic when requested by Caplin Support.
-    *   `--help`: display help
+    *   `--help`: display help and exit
+    *   `--version`: display version and exit
 
 **Run as**:
 

--- a/caplin-corefile-diagnostics.sh
+++ b/caplin-corefile-diagnostics.sh
@@ -23,6 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+VERSION=0.0.12
+
 SCRIPT_FILE=$(basename "$0")
 SCRIPT_DIR=$(dirname "$0")
 
@@ -65,6 +67,7 @@ EOF
 )"
 
 SHOW_HELP=0
+SHOW_VERSION=0
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
@@ -72,6 +75,10 @@ do
   case "$key" in
       -h|--help)
       SHOW_HELP=1
+      shift
+      ;;
+      -v|--version)
+      SHOW_VERSION=1
       shift
       ;;
       *)
@@ -82,13 +89,17 @@ do
 done
 set -- "${POSITIONAL[@]}"
 
-if [ $# -eq 0 ]; then
-  printf '%s\n\n' "$HELP"
-  exit 1
-fi
 if [ $SHOW_HELP -eq 1 ]; then
   printf '%s\n\n' "$HELP"
   exit 0
+fi
+if [ $SHOW_VERSION -eq 1 ]; then
+  printf '%s\n\n' "$VERSION"
+  exit 0
+fi
+if [ $# -eq 0 ]; then
+  printf '%s\n\n' "$HELP"
+  exit 1
 fi
 if [ ! -w . ]; then
   echo "This script must be run from a writeable directory. Aborting."


### PR DESCRIPTION
Handle ptrace 'access mode check' failures more gracefully. Detect when `/proc/<pid>/exe` is not readable by the script user (indicative of a ptrace check failure), and prompt the user to try rerunning the script as root. If the user chooses to continue regardless, run a minimal set of diagnostics.